### PR TITLE
Enable GitHub Pages deployment

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,41 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: 'pages'
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-hugo@v1
+        with:
+          hugo-version: '0.121.1'
+      - name: Build
+        run: hugo --minify
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: ./public
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1
+

--- a/README.md
+++ b/README.md
@@ -14,3 +14,17 @@ This repository contains the source for **MyResearchNotes**, a Hugo-based blog i
 ## Deployment
 
 The site can be deployed by running `hugo` and uploading the generated `public` directory to your hosting provider or GitHub Pages.
+
+## GitHub Pages
+
+This repository includes a GitHub Actions workflow that automatically builds the
+site with Hugo and publishes it to GitHub Pages. To enable automated deployment:
+
+1. Configure GitHub Pages in your repository settings to use the `gh-pages`
+   branch.
+2. Update the `baseURL` field in `config.toml` to match your GitHub Pages URL,
+   for example `https://<USERNAME>.github.io/<REPOSITORY>/`.
+3. Push changes to the `main` branch. The workflow will build and deploy the
+   site.
+
+The published blog will be available at your configured GitHub Pages URL.

--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,6 @@
-baseURL = "/"
+# Update this value to your GitHub Pages URL, e.g.
+# "https://<USERNAME>.github.io/<REPOSITORY>/" if hosting as a project page.
+baseURL = "https://example.github.io/"
 title = "MyResearchNotes"
 languageCode = "en-us"
 


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build and deploy to GitHub Pages
- configure `baseURL` for Pages hosting
- document GitHub Pages setup in README

## Testing
- `git status --short`